### PR TITLE
Compatibility update for WoW 11.0.0 and code optimizations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "Lua.diagnostics.globals": [
         "InterfaceOptions_AddCategory",
         "SlashCmdList",
-        "InterfaceOptionsFrame_OpenToCategory"
+        "InterfaceOptionsFrame_OpenToCategory",
+        "Settings"
     ]
 }

--- a/Bluedai-RandomTitle.toc
+++ b/Bluedai-RandomTitle.toc
@@ -1,10 +1,10 @@
-## Interface: 100207
+## Interface: 110000
 ## Title: Bluedai-Random Title
 ## Title-deDE: Bluedai-Random Title
 ## Notes: Change your character's title randomly with various trigger options!
 ## Notes-deDE: Ändere deinen Charaktertitel zufällig mit verschiedenen Auslöseoptionen!
 ## Author: Bluedai
-## Version: 0.3.2
+## Version: 0.4.0
 ## SavedVariables:
 ## SavedVariablesPerCharacter: Bluedai_RT
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,22 @@ RandomTitle allows you to change your WoW character's title at every login or on
 ### Version History
 
 
-**0.3.2 -09.05.2024**
+**0.4.0 - 24.07.2024**
+- compatibility with WoW 11.0.0
+
+- **API Changes:**
+  - config.lua: The method InterfaceOptions_AddCategory was replaced with Settings.RegisterCanvasLayoutCategory because it no longer works after patch 11.0.
+  - minimap.lua: Updated to reflect changes in the configuration method. The call to InterfaceOptionsFrame_OpenToCategory was replaced with Settings.OpenToCategory.
+
+- **Code Optimizations:**
+  - Introduced Bluedai_RT_Variables to store global variables, starting with the new category variable.
+
+**0.3.2 - 09.05.2024**
 
 #### Improvements and Changes:
 - compatibility with WoW 10.2.7
 
-**0.3.1 -23.03.2024**
+**0.3.1 - 23.03.2024**
 
 #### Improvements and Changes:
 - compatibility with WoW 10.2.6

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,10 @@
 -- https://wowpedia.fandom.com/wiki/Using_the_Interface_Options_Addons_panel
 local panel = CreateFrame("Frame")
 panel.name = "Bluedai-Random Title"
-InterfaceOptions_AddCategory(panel)
+-- InterfaceOptions_AddCategory(panel) - doesn't work after 11.0 patch
+local category, layout = Settings.RegisterCanvasLayoutCategory(panel, "Bluedai-Random Title")
+Settings.RegisterAddOnCategory(category)
+Bluedai_RT_Variables.Category = category -- Save the category for minimap.lua
 
 -- Title
 local title = panel:CreateFontString("ARTWORK", nil, "GameFontNormalLarge")
@@ -105,4 +108,6 @@ local function OptionIgnoredTitles()
     -- Stelle die tatsächliche Höhe von 'content' basierend auf der Anzahl der Checkboxen ein
     content:SetHeight(totalHeight)
 end
+
+-- global functions
 Bluedai_RT_Functions.OptionIgnoredTitles = OptionIgnoredTitles

--- a/core.lua
+++ b/core.lua
@@ -2,6 +2,7 @@
 -- Bluedai_RT.IgnoredTitles
 -- Bluedai_RT.MyTitles
 -- Bluedai_RT_Functions = {}
+-- Bluedai_RT_Variables = {}
 
 local function LoadTitles()
     Bluedai_RT.MyTitles = {}

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,5 @@
 Bluedai_RT_Functions = {}
+Bluedai_RT_Variables = {}
 
 local frame = CreateFrame("FRAME") -- Need a frame to respond to events
 frame:RegisterEvent("ADDON_LOADED") -- Fired when saved variables are loaded

--- a/minimap.lua
+++ b/minimap.lua
@@ -15,7 +15,6 @@ ring:SetTexCoord(0, 0.6, 0, 0.6)
 ring:SetPoint("CENTER", minimapButton, "CENTER", 0, 0)
 ring:SetTexture("Interface\\Minimap\\minimap-trackingborder")
 
-
 -- set symbol 
 local icon = minimapButton:CreateTexture(nil, "BACKGROUND")
 icon:SetSize(25, 25)
@@ -40,7 +39,12 @@ minimapButton:SetScript("OnClick", function(self, button)
         Bluedai_RT_Functions.SetRandomTitle()
     end
     if button == "RightButton" then
-        InterfaceOptionsFrame_OpenToCategory("Bluedai-Random Title")
+        local category = Bluedai_RT_Variables.Category
+        if category then
+            Settings.OpenToCategory(category:GetID())
+        else
+            print("Category not found")
+        end
     end
 end)
 


### PR DESCRIPTION
- Replaced InterfaceOptions_AddCategory with Settings.RegisterCanvasLayoutCategory in config.lua due to patch 11.0.
- Updated minimap.lua to use Settings.OpenToCategory instead of InterfaceOptionsFrame_OpenToCategory.
- Introduced Bluedai_RT_Variables to store global variables, starting with the new category variable.