### PR TITLE
Instantly detect new titles

### DIFF
--- a/Bluedai-RandomTitle.toc
+++ b/Bluedai-RandomTitle.toc
@@ -1,10 +1,10 @@
-## Interface: 110005, 110007
+## Interface: 110007
 ## Title: Bluedai-Random Title
 ## Title-deDE: Bluedai-Random Title
 ## Notes: Change your character's title randomly with various trigger options!
 ## Notes-deDE: Ändere deinen Charaktertitel zufällig mit verschiedenen Auslöseoptionen!
 ## Author: Bluedai
-## Version: 0.4.4
+## Version: 0.4.5
 ## IconTexture: Interface\Icons\Inv_misc_notefolded2a
 ## SavedVariables:
 ## SavedVariablesPerCharacter: Bluedai_RT

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ RandomTitle allows you to change your WoW character's title at every login or on
 
 ### Version History
 
+**0.4.5 - 11.01.2025**
+- **Feature Additions:**
+  - New titles are now immediately recognized and available without requiring a relog.
+  - Improved handling of titles granted shortly after login due to a WoW bug.
+
 **0.4.4 - 22.11.2024**
 - compatibility with WoW 11.0.7
 - Added icon to the addon list

--- a/core.lua
+++ b/core.lua
@@ -19,6 +19,18 @@ local function LoadTitles()
 end
 Bluedai_RT_Functions.LoadTitles = LoadTitles
 
+local isLoadingTitles = false
+local function SafeLoadTitles()
+    if isLoadingTitles then
+        return
+    end
+    isLoadingTitles = true
+    Bluedai_RT_Functions.LoadTitles()
+    Bluedai_RT_Functions.configPanelUpdate()
+    isLoadingTitles = false
+end
+Bluedai_RT_Functions.SafeLoadTitles = SafeLoadTitles
+
 local function show_new_title()
     if Bluedai_RT_Variables.show and Bluedai_RT.EnabledshownewTitle then
         local new_title = UnitPVPName("player")

--- a/init.lua
+++ b/init.lua
@@ -8,6 +8,7 @@ local frame = CreateFrame("FRAME") -- Need a frame to respond to events
 frame:RegisterEvent("ADDON_LOADED") -- Fired when saved variables are loaded
 frame:RegisterEvent("PLAYER_ENTERING_WORLD") -- Fired when entering world and Titles are available
 frame:RegisterEvent("UNIT_NAME_UPDATE") -- Fired when the player's name change
+frame:RegisterEvent("KNOWN_TITLES_UPDATE") -- Fired when the player's titles change
 
 local function LoginResponse()
   local ResponseFrame = CreateFrame("Frame", "BluedaiRTFrame", UIParent, "BasicFrameTemplateWithInset")
@@ -63,12 +64,14 @@ function frame:OnEvent(event, arg1)
     frame:UnregisterEvent("ADDON_LOADED")
   end
   if event == "PLAYER_ENTERING_WORLD" then
-    Bluedai_RT_Functions.LoadTitles()
-    Bluedai_RT_Functions.OptionIgnoredTitles()
+    Bluedai_RT_Functions.SafeLoadTitles()
     if Bluedai_RT.EnabledLoginResponse then
       LoginResponse()
     end
     frame:UnregisterEvent("PLAYER_ENTERING_WORLD")
+  end
+  if event == "KNOWN_TITLES_UPDATE" then
+   Bluedai_RT_Functions.SafeLoadTitles()
   end
   if event == "UNIT_NAME_UPDATE" and arg1 == "player" then
     Bluedai_RT_Functions.show_new_title()


### PR DESCRIPTION
New titles are now immediately recognized and available without requiring a relog